### PR TITLE
feat: support Netlify

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function supportsHyperlink(stream) {
 		return false;
 	}
 
+	if ('NETLIFY' in env) {
+		return true;
+	}
+
 	if ('CI' in env) {
 		return false;
 	}

--- a/test.js
+++ b/test.js
@@ -243,6 +243,15 @@ test('disabled in TEAMCITY', t => {
 	}));
 });
 
+test('enabled in Netlify build logs', t => {
+	t.true(isSupported({
+		env: {
+			CI: 'true',
+			NETLIFY: 'true'
+		}
+	}));
+});
+
 test('not supported if TERM_PROGRAM exists, but TERM_VERSION does not', t => {
 	t.false(isSupported({
 		env: {


### PR DESCRIPTION
This adds support for Netlify.

Netlify build logs supports some ANSI sequences using [`ansi_up`](https://github.com/drudru/ansi_up) which [supports OSC hyperlinks](https://github.com/drudru/ansi_up/blob/c8c726ed1db979bae4f257b7fa41775155ba2e27/ansi_up.ts#L378).

However, Netlify sets the `CI` enviroment variable, which makes this library return `false`. 

This PR adds support for Netlify by detecting it with the `NETLIFY` environment variable.