### PR TITLE
fix: Netlify support

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function supportsHyperlink(stream) {
 		return true;
 	}
 
+	// Netlify does not run a TTY, it does not need `supportsColor` check
 	if ('NETLIFY' in env) {
 		return true;
 	}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ function supportsHyperlink(stream) {
 		return true;
 	}
 
+	if ('NETLIFY' in env) {
+		return true;
+	}
+
 	// If they specify no colors, they probably don't want hyperlinks.
 	if (!supportsColor.supportsColor(stream)) {
 		return false;
@@ -47,10 +51,6 @@ function supportsHyperlink(stream) {
 
 	if (process.platform === 'win32') {
 		return false;
-	}
-
-	if ('NETLIFY' in env) {
-		return true;
 	}
 
 	if ('CI' in env) {


### PR DESCRIPTION
This is a follow-up on #11.

Netlify CI does not run a TTY, so `supports-hyperlinks` currently returns `false`, even though OSC hyperlinks are supported in Netlify (through the `ansi_up` dependency).

This PR fixes this by changing the position of the Netlify condition.