### PR TITLE
Update .gitignore to include index.d.ts in release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 yarn.lock
 .nyc_output
 coverage
-index.d.ts


### PR DESCRIPTION
Quite sure you want to publish the typing so we can use this in a typescript project without manually declaring types