### PR TITLE
Add basic GitHub Action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,35 @@
+name: Node Tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node ${{ matrix.node_version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [14,16,18]
+        os: ['ubuntu-latest']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '10'
-  - '8'
-after_script:
-  - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'


### PR DESCRIPTION
travis-ci.org is no more, so this repo is currently without CI tests: https://blog.travis-ci.com/2021-05-07-orgshutdown

Here's a basic GitHub Action setup.

Stuff this PR doesn't do:

* Does not remove the travis configuration
* Does not set up CodeCov (I think that requires setting an API key or something as an owner)