### PR TITLE
Add support for alacritty

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function supportsHyperlink(stream) {
 
 	switch (TERM) {
 		case 'alacritty':
-			// NB. no quick ver check. support added v0.11 (2022-10-13)
+			// Support added v0.11 (2022-10-13)
 			return true;
 		// No default
 	}

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function supportsHyperlink(stream) {
 
 	switch (TERM) {
 		case 'alacritty':
-			// Support added v0.11 (2022-10-13)
+			// Support added in v0.11 (2022-10-13)
 			return true;
 		// No default
 	}

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ function supportsHyperlink(stream) {
 		TEAMCITY_VERSION,
 		TERM_PROGRAM,
 		TERM_PROGRAM_VERSION,
-		VTE_VERSION
+		VTE_VERSION,
+		TERM,
 	} = process.env;
 
 	if (FORCE_HYPERLINK) {
@@ -105,6 +106,13 @@ function supportsHyperlink(stream) {
 
 		const version = parseVersion(VTE_VERSION);
 		return version.major > 0 || version.minor >= 50;
+	}
+
+	switch (TERM) {
+		case 'alacritty':
+			// NB. no quick ver check. support added v0.11 (2022-10-13)
+			return true;
+		// No default
 	}
 
 	return false;

--- a/test.js
+++ b/test.js
@@ -180,6 +180,7 @@ test('supported in VTE 5105 (0.51.5)', t => {
 		}
 	}));
 });
+
 test('supported in alacritty', t => {
 	t.true(isSupported({
 		env: {
@@ -187,6 +188,7 @@ test('supported in alacritty', t => {
 		},
 	}));
 });
+
 test('empty env not supported', t => {
 	t.false(isSupported({env: {}}));
 });

--- a/test.js
+++ b/test.js
@@ -180,6 +180,16 @@ test('supported in VTE 5105 (0.51.5)', t => {
 		}
 	}));
 });
+test('supported in alacritty', t => {
+	t.true(isSupported({
+		env: {
+			TERM: 'alacritty',
+		},
+	}));
+});
+test('empty env not supported', t => {
+	t.false(isSupported({env: {}}));
+});
 
 test.failing('no-color flag disables support', t => {
 	t.false(isSupported({


### PR DESCRIPTION
adding `alacritty` from #2.

Pulling in new environmental variable `TERM` and checking with case statement even though currently it only checks for alaritty. Other terminals (terminology?) might set TERM. and xterm might have support in the future